### PR TITLE
Favoritos seleção alunos

### DIFF
--- a/src/controllers/dataController.js
+++ b/src/controllers/dataController.js
@@ -40,7 +40,7 @@ module.exports = () => {
 
   // FavoriteStudentOpportunities
   dataController.saveFavoriteStudentOpportunities = (req, res, next) => {
-    save(dataService().saveFavoriteStudentOpportunity, req, res, next);
+    save(dataService().saveFavoriteStudentOpportunities, req, res, next);
   };
 
   dataController.getFavoriteStudentOpportunities = (req, res, next) => {

--- a/src/controllers/dataController.js
+++ b/src/controllers/dataController.js
@@ -38,6 +38,21 @@ module.exports = () => {
       : new Array(width - number.length + 1).join(z) + number;
   };
 
+  // FavoriteStudentOpportunities
+  dataController.saveFavoriteStudentOpportunities = (req, res, next) => {
+    save(dataService().saveFavoriteStudentOpportunity, req, res, next);
+  };
+
+  dataController.getFavoriteStudentOpportunities = (req, res, next) => {
+    get(
+      dataService().getFavoriteStudentOpportunities,
+      parseInt(req.decodedToken.sub),
+      req,
+      res,
+      next
+    );
+  };
+
   // FavoritePublicTender
   dataController.saveFavoritePublicTender = (req, res, next) => {
     save(dataService().saveFavoritePublicTender, req, res, next);

--- a/src/routes/data.js
+++ b/src/routes/data.js
@@ -35,5 +35,14 @@ module.exports = app => {
     dataController.getFavoritePublicTender
   );
 
+  app.post(
+    "/studentOpportunities/data/favorite",
+    dataController.saveFavoriteStudentOpportunities
+  );
+  app.get(
+    "/studentOpportunities/data/favorite",
+    dataController.getFavoriteStudentOpportunities
+  );
+
   return app;
 };

--- a/src/services/dataService.js
+++ b/src/services/dataService.js
@@ -75,12 +75,22 @@ const publicTenderBaseModel = tableName => {
   return entity;
 };
 
+const studentOpportunitiesBaseModel = tableName => {
+  const entity = thinky.createModel(tableName, {
+    id: type.number(),
+    date: type.date().default(new Date()),
+    idOpportunity: [type.number()]
+  });
+  return entity;
+};
+
 const FavoriteBusLines = baseModel("favoriteBusLines");
 const FavoriteBuscaBus = baseModel("favoriteBuscaBus");
 const Settings = baseModel("settings");
 const Vehicles = vehicleBaseModel("vehicles");
 const FavoriteSepProtocol = sepBaseModel("favoriteSepProtocol");
 const FavoritePublicTender = publicTenderBaseModel("favoritePublicTender");
+const FavoriteStudentOpportunities = studentOpportunitiesBaseModel("favoriteStudentOpportunities")
 
 module.exports = () => {
   const dataService = new Object();
@@ -115,6 +125,15 @@ module.exports = () => {
           throw err;
         }
       });
+  };
+
+  // FavoriteStudentOpportunities
+  dataService.saveFavoriteStudentOpportunities = data => {
+    return save(FavoriteStudentOpportunities, data);
+  };
+
+  dataService.getFavoriteStudentOpportunities = userId => {
+    return FavoriteStudentOpportunities.get(userId).run();
   };
 
   // FavoritePublicTender


### PR DESCRIPTION
## Favoritos do seleção aluno

Foi implementado favoritos do seleção aluno seguindo o mesmo padrão das rotas antigas de favoritos.

## Passos para reproduzir

1. Configure as variáveis de ambiente necessárias ou o arquivo `.env`
2. `$ npm install` e `$ npm start`
3. Copie um token válido em `http://prodest.github.io/es-na-palma-da-mao-mobile/latest/preview`
4. Faça as requisições de favoritos:

- POST `/studentOpportunities/data/favorite`: Salvar favorito do usuário
Ex de body:

```json
{
  "idOpportunity": []
}
```
- GET `/studentOpportunities/data/favorite`: Obter favoritos do usuário

## Áreas impactadas na aplicação

* Novas rotas de favoritos para oportunidade aluno

## Observações de deploy

- N/A